### PR TITLE
Update draft-dt-tls-external-psk-guidance.md

### DIFF
--- a/draft-dt-tls-external-psk-guidance.md
+++ b/draft-dt-tls-external-psk-guidance.md
@@ -282,7 +282,7 @@ Applications MUST use external PSKs that adhere to the following requirements:
 128 bits long, and SHOULD be combined with a DH exchange for forward secrecy. As
 discussed in {{sec-properties}}, low entropy PSKs, i.e., those derived from less
 than 128 bits of entropy, are subject to attack and SHOULD be avoided. Low entropy
-key are only secure against active attack if a PAKE, and not a PSK, is used with TLS.
+keys are only secure against active attack if a Password Authenticated Key Exchange (PAKE) is used with TLS.
 2. Each PSK MUST NOT be shared between with more than two logical nodes. As a
 result, an agent that acts as both a client and a server MUST use distinct PSKs
 when acting as the client from when it is acting as the server.

--- a/draft-dt-tls-external-psk-guidance.md
+++ b/draft-dt-tls-external-psk-guidance.md
@@ -344,11 +344,6 @@ execute the application's registered callback function before checking the stack
 internal session resumption cache. This means that if a PSK identity collision occurs,
 the application will be given precedence over how to handle the PSK.
 
-[[TODO.. the application still does not know if an identity collision occured or not.
-If we wanted to be 100% explicit, the stack would check its resumption cache and then
-callback the application indicating here is a PSK that has a cache hit, please check
-your external PSK DB, and let me know how to proceed. Seems like overkill for something
-that should not happen.]]
 
 # Security Considerations {#security-con}
 

--- a/draft-dt-tls-external-psk-guidance.md
+++ b/draft-dt-tls-external-psk-guidance.md
@@ -339,7 +339,7 @@ to avoid obvious collisions.
 It is possible, though unlikely, that an external PSK identity may clash with a
 resumption PSK identity. The TLS stack implementation and sequencing of PSK callbacks
 influences the application's behaviour when identity collisions occur. When a server
-receives a PSK identity in a TLS 1.3 ClientHello, OpenSSL, BoringSSL and mbedTLS 
+receives a PSK identity in a TLS 1.3 ClientHello, some TLS stacks
 execute the application's registered callback function before checking the stack's
 internal session resumption cache. This means that if a PSK identity collision occurs,
 the application will be given precedence over how to handle the PSK.


### PR DESCRIPTION
FIxed up:
- some nits on recommendations. I think the wording was a bit off on low entropy PSKs, so I lifted from ekrs text from earlier in the draft.
- some of the stack interface stuff on hints is not valid for TLS1.3 (hints are TLS1.2 and earlier), so removed it.

Some prelim text on collisions. For completeness, will take a look at gnutls and wolfssl order too. Note, even with the OpenSSL callback sequence, the application still does not know if there is a collision...
