### PR TITLE
Add note that using SNI mitigates rerouting attacks.

### DIFF
--- a/draft-ietf-tls-external-psk-guidance.md
+++ b/draft-ietf-tls-external-psk-guidance.md
@@ -164,7 +164,8 @@ attacker to passively read all traffic.
 
 In addition to these, a malicious non-member can reroute handshakes
 between honest group members to connect them in unintended ways, as
-detailed below.
+detailed below. (Note that this class of attack is not possible if each party uses
+the SNI extension and terminates the connection on mismatch {{!RFC6066}}{{Selfie}}.)
 
 Let the group of peers who know the key be `A`, `B`, and `C`.
 The attack proceeds as follows:


### PR DESCRIPTION
The Selfie paper points out that if each party uses the SNI extension and terminates a connection on mismatch, rerouting attacks like Selfie aren't possible. I added this note to the explanation of such attacks.