### PR TITLE
Nit: Remove 'obvious' from 'obvious collisions.'

### DIFF
--- a/draft-ietf-tls-external-psk-guidance.md
+++ b/draft-ietf-tls-external-psk-guidance.md
@@ -354,7 +354,7 @@ Extensible Authentication Protocol (EAP) {{?RFC3748}}. gnuTLS for example treats
 PSK identities as usernames.
 - PSK identities MAY have a domain name suffix for roaming and federation.
 - Deployments should take care that the length of the PSK identity is sufficient
-to avoid obvious collisions.
+to avoid collisions.
 
 ### PSK Identity Collisions
 


### PR DESCRIPTION
I'm not sure what makes a collision obvious versus non-obvious, so let's remove the word "obvious."