### PR TITLE
Change 'fast open' to 'early data.'

### DIFF
--- a/draft-ietf-tls-external-psk-guidance.md
+++ b/draft-ietf-tls-external-psk-guidance.md
@@ -227,7 +227,7 @@ online protocol.
 
 - Intra-data-center communication. Machine-to-machine communication within a single data center
 or PoP may use externally provisioned PSKs, primarily for the purposes of supporting TLS
-connections with early data (a.k.a. 0-RTT data).
+connections with early data.
 
 - Certificateless server-to-server communication. Machine-to-machine communication
 may use externally provisioned PSKs, primarily for the purposes of establishing TLS

--- a/draft-ietf-tls-external-psk-guidance.md
+++ b/draft-ietf-tls-external-psk-guidance.md
@@ -227,7 +227,7 @@ online protocol.
 
 - Intra-data-center communication. Machine-to-machine communication within a single data center
 or PoP may use externally provisioned PSKs, primarily for the purposes of supporting TLS
-connections with fast open (0-RTT data).
+connections with early data (a.k.a. 0-RTT data).
 
 - Certificateless server-to-server communication. Machine-to-machine communication
 may use externally provisioned PSKs, primarily for the purposes of establishing TLS


### PR DESCRIPTION
Since the term 'fast open' isn't used in RFC 8446, replace 'fast open' with the term that RFC 8446 uses for '0-RTT data'--namely, 'early data.'